### PR TITLE
Discussion Notes of OS Distributed Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ We're going to learn computer science! Once a week we'll meet and work on proble
 | Progress | Date | Topic Chapter | Chapter Discussion Notes |
 |:----------|:-------------|:------|:------|
 | | 12/1 | [Virtualization: Process Intro](https://pages.cs.wisc.edu/~remzi/OSTEP/cpu-intro.pdf) | [Notes](operating-systems/process-intro-notes.md) |
-| :point_right: | 12/9 | [Concurrency: Threads Intro](https://pages.cs.wisc.edu/~remzi/OSTEP/threads-intro.pdf) | [Notes](operating-systems/concurrency-intro-notes.md) |
-| | 12/16 | [Persistence: Distributed Systems Intro](https://pages.cs.wisc.edu/~remzi/OSTEP/dist-intro.pdf) | |
+| | 12/9 | [Concurrency: Threads Intro](https://pages.cs.wisc.edu/~remzi/OSTEP/threads-intro.pdf) | [Notes](operating-systems/concurrency-intro-notes.md) |
+| :point_right: | 12/16 | [Persistence: Distributed Systems Intro](https://pages.cs.wisc.edu/~remzi/OSTEP/dist-intro.pdf) | [Notes](operating-systems/distributed-systems-intro-notes.md) |
 
 **Subject:** Networking \
 **Resource:** [Computer Networking: A Top-Down Approach](https://gaia.cs.umass.edu/kurose_ross/wireshark.php)

--- a/operating-systems/distributed-systems-intro-notes.md
+++ b/operating-systems/distributed-systems-intro-notes.md
@@ -1,0 +1,26 @@
+## Resource
+
+**Subject:** Operating Systems \
+**Resource:** [Operating Systems: Three Easy Pieces](https://pages.cs.wisc.edu/~remzi/OSTEP/)
+
+## Weekly Reading
+
+[Persistence: Distributed Systems Intro](https://pages.cs.wisc.edu/~remzi/OSTEP/dist-intro.pdf)
+
+### Notes
+
+**Backgound Notes**
+
+**Discussion Notes**
+
+#### Dec 16, 2022
+- Interuptions in communications exist? / bit flipping is weird
+- Datagram = piece of data of fixed size (can be interchanged) + checksum + ? + address (to/from)
+- It sounds like distributed systems don't share address space like a multi-threaded process would...but also they do share some data?
+	- they have their own machine/memory but also working together as part of larger system
+- What kindof data does a multi-threaded machine send back and forth?
+	- 1 system with multi-threading: operating on same heap 
+	- Distributed system: there's shared virtual memory (somewhere) that everyone is operating on
+    - ^ So what kind of data gets sent between the i/o api in process is different than api within distributed system
+- what's the purpose of message buffer? Is it the "to-go container" or the "order ticket as food goes out"?
+


### PR DESCRIPTION
Our WIP notes on [OS Persistence: Distributed Systems Intro](https://pages.cs.wisc.edu/~remzi/OSTEP/dist-intro.pdf) reading from discussion on 12/16.

Currently as a branch off of the concurrency discussion notes as README progress builds.